### PR TITLE
Use ComputerName as suggested clientname

### DIFF
--- a/src/win32/installer/winburp.nsi
+++ b/src/win32/installer/winburp.nsi
@@ -187,7 +187,12 @@ Function .onInit
 
 	StrCpy $ConfigServerAddress		"10.0.0.1"
 	StrCpy $ConfigServerPort              "4971"
-	StrCpy $ConfigClientName              "clientname"
+	ReadRegStr $0 HKLM "System\CurrentControlSet\Control\ComputerName\ComputerName" "ComputerName"
+	${If} $0 == ""
+		StrCpy $ConfigClientName 	"clientname"
+	${Else}
+		StrCpy $ConfigClientName $0
+	${EndIf}
 	StrCpy $ConfigPassword                "abcdefgh"
 	StrCpy $ConfigPoll                    "20"
 	StrCpy $ConfigAutoupgrade		"0"


### PR DESCRIPTION
This patch uses the Computername from the windows registry as suggested clientname instead of just "clientname".