### PR TITLE
Warn only once for not machting client version

### DIFF
--- a/src/server/auth.c
+++ b/src/server/auth.c
@@ -97,7 +97,6 @@ void version_warn(struct asfd *asfd, struct conf **confs, struct conf **cconfs)
 		else
 			snprintf(msg, sizeof(msg), "Client '%s' version '%s' does not match server version '%s'. An upgrade is recommended.", cname?cname:"unknown", peer_version, PACKAGE_VERSION);
 		if(confs) logw(asfd, get_cntr(confs), "%s\n", msg);
-		logp("WARNING: %s\n", msg);
 	}
 }
 


### PR DESCRIPTION
Warn only once and when configured in the conf file when the client version is not identical to the server version.